### PR TITLE
Fixed vcf parsing: do not skip phased genotpyes

### DIFF
--- a/src/extract
+++ b/src/extract
@@ -228,6 +228,10 @@ def hetero_and_homo_snps(vcf):
         values = lst[9].split(":")
         dict = { annotations[i]:values[i] for i in range(0, len(annotations)) }
 
+        # Manage phased genotypes
+        if dict["GT"][1] == "|":
+            dict["GT"] = dict["GT"].replace("|", "/")
+
         # if it's a single heterozygous SNP
         if ((len(lst[3]) == len(lst[4]) == 1) and (dict["GT"]=="0/1")):
 

--- a/src/stats
+++ b/src/stats
@@ -92,6 +92,10 @@ def hetero_and_homo_snps(vcf):
         values = lst[9].split(":")
         dict = { annotations[i]:values[i] for i in range(0, len(annotations)) }
 
+        # Manage phased genotypes
+        if dict["GT"][1] == "|":
+            dict["GT"] = dict["GT"].replace("|", "/")
+
         # if it's a single heterozygous SNP
         if ((len(lst[3]) == len(lst[4]) == 1) and (dict["GT"]=="0/1")):
 


### PR DESCRIPTION
Hi,
I was trying your tool when I realized that it misses phased genotypes (see section 1.4.2 of VCF standard definition https://samtools.github.io/hts-specs/VCFv4.2.pdf). Hence, jloh skipped a lot of SNPs. Here is a suggestion to fix this problem.