### PR TITLE
Update Dockerfile with chmod 755 /root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,6 +73,9 @@ RUN cd /root/src \
     && git clone -b v1.0.3 https://github.com/Gabaldonlab/jloh.git \
     && ln -s /root/src/jloh/jloh /usr/bin
 
+#Change permissions making Docker to Singularity/Apptainer conversions usable
+RUN chmod 755 /root
+
 #Purge unnecessary dependencies
 RUN apt purge -y git make g++ zlib1g-dev python3-pip automake wget curl make zlib1g-dev libbz2-dev libncurses5-dev libncursesw5-dev liblzma-dev libzstd-dev libreadline6-dev libxt-dev \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Some researchers using Public cluster will have to pull this image as an Apptainer/Singularity image. However, exiting permissions on `/usr/local/bin/jloh` under root:root will make the executable obsolete for them. add `chmod 755 /root`
 will fix this