### PR TITLE
handle single and float af values

### DIFF
--- a/src/onco_extract
+++ b/src/onco_extract
@@ -154,7 +154,6 @@ def generate_unique_key(output_dir):
 
     return unique_key    
 
-
 def extract_variants(vcf_input, vcf_output, min_af, max_af, dir, name):
     
     '''
@@ -171,7 +170,6 @@ def extract_variants(vcf_input, vcf_output, min_af, max_af, dir, name):
     else:
         raise ValueError("ERROR. Please provide a valid VCF file as input")
 
-
     #store the paths of the file that are going to be created to use them afterwards
     hetero_vcf_output = f"{dir}/hetero_{vcf_output}{name}.vcf"
     homo_vcf_output = f"{dir}/homo_{vcf_output}{name}.vcf"
@@ -187,27 +185,64 @@ def extract_variants(vcf_input, vcf_output, min_af, max_af, dir, name):
             if args.filter_mode: #filter-vcf is provided by the user
                  if "PASS" in record.FILTER:  # Check if FILTER annotation is "PASS"
                     af_values = record.calls[0].data.get("AF", [])  # Get AF values, obtain an empty value if its not available (debugging)
-                    if af_values and max_af > af_values[0] > min_af:  #default: max=0.70 and min=0.30                 
-                        writer_het.write_record(record)
-                        hetero_lines.append(str(record))
-                    else: #homo variants
-                        writer_homo.write_record(record)
-                        homo_lines.append(str(record))
+                    # Fix: Handle both float and list cases
+                    if af_values:
+                        if isinstance(af_values, (int, float)):
+                            af_check = af_values
+                        else:
+                            af_check = af_values[0]
+
+                        if max_af > af_check > min_af:  #default: max=0.70 and min=0.30
+                            writer_het.write_record(record)
+                            hetero_lines.append(str(record))
+                        else: #homo variants
+                            writer_homo.write_record(record)
+                            homo_lines.append(str(record))
             else:
                 # --filter-vcf option is not provided, write all variants
                 af_values = record.calls[0].data.get("AF", [])  # Get AF values, obtain an empty value if its not available (debugging)
-                if af_values and max_af > af_values[0] > min_af:  #default: max=0.70 and min=0.30                  
-                    writer_het.write_record(record)
-                    hetero_lines.append(str(record)) #count length of snps found
-                else: #homo variants
-                    writer_homo.write_record(record)
-                    homo_lines.append(str(record))
+                # Fix: Handle both float and list cases
+                if af_values:
+                    if isinstance(af_values, (int, float)):
+                        af_check = af_values
+                    else:
+                        af_check = af_values[0]
+
+                    if max_af > af_check > min_af:  #default: max=0.70 and min=0.30
+                        writer_het.write_record(record)
+                        hetero_lines.append(str(record)) #count length of snps found
+                    else: #homo variants
+                        writer_homo.write_record(record)
+                        homo_lines.append(str(record))
         else:
             continue
     
     vcf.close()
     return hetero_vcf_output, homo_vcf_output, hetero_lines, homo_lines
 
+def divide_homo_vcf(homo_vcf,args, sample):
+    vcf=vcfpy.Reader.from_path(homo_vcf, "r")
+    homo_ALT_vcf_output = f"{args.output_dir}/homo_ALT{sample}.vcf"
+    homo_REF_vcf_output =  f"{args.output_dir}/homo_REF{sample}.vcf"
+    writer_ALT=vcfpy.Writer.from_path(homo_ALT_vcf_output, vcf.header)
+    writer_REF=vcfpy.Writer.from_path(homo_REF_vcf_output, vcf.header)
+
+    for record in vcf:
+        af_values = record.calls[0].data.get("AF", [])  # Get AF values, obtain an empty value if its not available (debugging)
+        # Fix: Handle both float and list cases
+        if af_values:
+            if isinstance(af_values, (int, float)):
+                af_check = af_values
+            else:
+                af_check = af_values[0]
+
+            if af_check > args.max_af:
+                writer_ALT.write_record(record)
+            elif af_check < args.min_af:
+                writer_REF.write_record(record)
+            else:
+                continue
+    return homo_ALT_vcf_output, homo_REF_vcf_output
 
 def parse_chromosomes(ref):
 
@@ -345,12 +380,19 @@ def divide_homo_vcf(homo_vcf,args, sample):
 
     for record in vcf:
         af_values = record.calls[0].data.get("AF", [])  # Get AF values, obtain an empty value if its not available (debugging)
-        if af_values and af_values[0] >args.max_af:
-            writer_ALT.write_record(record)
-        elif af_values and af_values[0] <args.min_af:
-            writer_REF.write_record(record)
-        else:
-            continue
+        # Fix: Handle both float and list cases
+        if af_values:
+            if isinstance(af_values, (int, float)):
+                af_check = af_values
+            else:
+                af_check = af_values[0]
+
+            if af_check > args.max_af:
+                writer_ALT.write_record(record)
+            elif af_check < args.min_af:
+                writer_REF.write_record(record)
+            else:
+                continue
     return homo_ALT_vcf_output, homo_REF_vcf_output
 
 


### PR DESCRIPTION
Runnin `jloh onco_extract` produces an error

```console
Apptainer> jloh onco_extract --ref test_data/S_para.chrXII.fa --vcfs test_data/out.ff.vcf te
st_data/out.ff.vcf --bams test_data/out.fs.bam test_data/out.fs.bam
[Thu Oct  2 11:15:22 2025] Initiating onco_Jloh: checking conditions and organizing workspace...Done
[Thu Oct  2 11:15:22 2025] Running in default mode...
[Thu Oct  2 11:15:22 2025] Extracting heterozygous and homozygous SNPs...
Traceback (most recent call last):
  File "/root/src/jloh/src/onco_extract", line 1347, in <module>
    main(args, tmp_bams, tmp_bams2)
  File "/root/src/jloh/src/onco_extract", line 1326, in main
    run_in_default_mode(args, tmp_bams, tmp_bams2)
  File "/root/src/jloh/src/onco_extract", line 894, in run_in_default_mode
    hetero_vcf_control, homo_vcf_control, hetero_lines_control, homo_lines_control=extract_variants(args.vcfs[0], args.sample, args.min_af, args.max_af,args.output_dir, "_control")
  File "/root/src/jloh/src/onco_extract", line 199, in extract_variants
    if af_values and max_af > af_values[0] > min_af:  #default: max=0.70 and min=0.30                  
TypeError: 'float' object is not subscriptable
```
Runs fine after handling different input `af_values`: floats or lists

```console
Apptainer> python3 src/onco_extract --ref test_data/S_para.chrXII.fa --vcfs test_data/out.ff.vcf test_data/out.ff.vcf --bams test_data/out.fs.bam test_data/out.fs.bam
[Thu Oct  2 11:15:29 2025] Initiating onco_Jloh: checking conditions and organizing workspace...Done
[Thu Oct  2 11:15:29 2025] Running in default mode...
[Thu Oct  2 11:15:29 2025] Extracting heterozygous and homozygous SNPs...
 Control: Found 12 heterozygous SNPs and 121 homozygous SNPs
 Tumor: Found 12 heterozygous SNPs and 121 homozygous SNPs
[Thu Oct  2 11:15:29 2025]Calculating heterozygous and homozygous SNPs densities...Done
 Control: 
 -Avg. heterozygous SNPs density: 0.0117 SNPs/Kbps
  -Avg. homozygous SNPs density: 0.1183 SNPs/Kbps 

 Tumor: 
 -Avg. heterozygous SNPs density: 0.0117 SNPs/Kbps
  -Avg. homozygous SNPs density: 0.1183 SNPs/Kbps 

[Thu Oct  2 11:15:29 2025] Creating genome file from reference genome's chromosome lengths...Done
 -Genome file created succesfully
[Thu Oct  2 11:15:29 2025] Temporary BAMs being created for control...Done
[Thu Oct  2 11:15:40 2025] Temporary BAMs being created for tumor...Done
[Thu Oct  2 11:15:53 2025] Clustering heterozygous and homozygous SNPs into blocks...Done
Found in control:
 -1 het blocks
 -9 homo ALT blocks
 -0 homo REF blocks
Found in tumor:
 -1 het blocks
 -9 homo ALT blocks
 -0 homo REF blocks
[Thu Oct  2 11:15:53 2025] Trimming overlaps with heterozygous SNPs...Done
 Control: 10 blocks were trimmed
 Tumor: 10 blocks were trimmed
[Thu Oct  2 11:15:53 2025] Trimming overlaps of homozygous blocks with uncovered regions...Done
 Control: 12 blocks were processed
 Tumor: 12 blocks were processed
[Thu Oct  2 11:16:00 2025]Filtering blocks with at least 100 bp of length ...Done
Control: 9 homo blocks survived the filtering
Tumor: 0 LOH blocks survived the filtering
[Thu Oct  2 11:16:00 2025] Computing coverage up- , in-, and downstream of any candidate block in control
...[Thu Oct  2 11:16:03 2025] Computing coverage up- , in-, and downstream of any candidate block in tumor...Done
Tumor: 0 LOH blocks were processed. 
[Thu Oct  2 11:16:05 2025] Adding heterozygous and homozygous SNP counts in each block...Done
 - Control: 3 blocks were processed
 - Tumor: 0 blocks were processed
[Thu Oct  2 11:16:05 2025] Sorting LOH blocks...Done
[Thu Oct  2 11:16:05 2025] Writing control to output...
[Thu Oct  2 11:16:05 2025] Writing tumor to output...
[Thu Oct  2 11:16:05 2025] Intersecting LOH blocks in tumor with preexisting homo blocks in control...Done
[Thu Oct  2 11:16:05 2025]  - 0 LOH blocks have been inferred on the tumoral sample
[Thu Oct  2 11:16:05 2025] Done!
  - Files generated can be found on oncojloh
[Thu Oct  2 11:16:05 2025] Statistics from the run:
 - CPU time used: 26.01 seconds
 - Memory usage change: 44.73 MB
 - Elapsed time: 1 minutes
 ```