### PR TITLE
Handle bed blocks in single mode

### DIFF
--- a/src/onco_extract
+++ b/src/onco_extract
@@ -374,12 +374,12 @@ def hetero_and_homo_snp_densities(ref,vcf, name):
 def divide_homo_vcf(homo_vcf,args, sample):
     vcf=vcfpy.Reader.from_path(homo_vcf, "r")
     homo_ALT_vcf_output = f"{args.output_dir}/homo_ALT{sample}.vcf"
-    homo_REF_vcf_output =  f"{args.output_dir}homo_REF{sample}.vcf"
+    homo_REF_vcf_output = f"{args.output_dir}/homo_REF{sample}.vcf"  # Added missing slash
     writer_ALT=vcfpy.Writer.from_path(homo_ALT_vcf_output, vcf.header)
     writer_REF=vcfpy.Writer.from_path(homo_REF_vcf_output, vcf.header)
 
     for record in vcf:
-        af_values = record.calls[0].data.get("AF", [])  # Get AF values, obtain an empty value if its not available (debugging)
+        af_values = record.calls[0].data.get("AF", [])
         # Fix: Handle both float and list cases
         if af_values:
             if isinstance(af_values, (int, float)):
@@ -1234,11 +1234,12 @@ def run_in_single_mode(args, tmp_bams, tmp_bams_control):
     sys.stderr.write(f"Done\n")
 
     # bed blocks
-    sys.stderr.write( f"[{at()}] Clustering heterozygous and homozygous SNPs into blocks...")
-    homo_vcf_ALT, homo_vcf_REF=divide_homo_vcf(homo_vcf, args, "_tumor")
-    Het_blocks, Homo_blocks_ALT, Homo_blocks_REF=snps_to_bed_blocks(args, hetero_vcf, homo_vcf_ALT,homo_vcf_REF, genome_file, "_tumor")
-    Het_blocks=filter_by_length(Het_blocks, args.min_length)
-    Het_blocks.saveas(f'{args.output_dir}/hetero_output_file.bed')  # Save the result to a file
+    sys.stderr.write(f"[{at()}] Clustering heterozygous and homozygous SNPs into blocks...")
+    homo_vcf_ALT, homo_vcf_REF = divide_homo_vcf(homo_vcf, args, "_tumor")
+    # FIXED: Removed extra "_tumor" parameter
+    Het_blocks, Homo_blocks_ALT, Homo_blocks_REF = snps_to_bed_blocks(args, hetero_vcf, homo_vcf_ALT, homo_vcf_REF, genome_file)
+    Het_blocks = filter_by_length(Het_blocks, args.min_length)
+    Het_blocks.saveas(f'{args.output_dir}/hetero_output_file.bed') # Save the result to a file
 
     sys.stderr.write(  "Done\n")
     sys.stderr.write(f"Found:\n -{len(Het_blocks)} het blocks\n -{len(Homo_blocks_ALT)} homo ALT blocks\n -{len(Homo_blocks_REF)} homo REF blocks\n")

--- a/src/onco_extract
+++ b/src/onco_extract
@@ -154,7 +154,6 @@ def generate_unique_key(output_dir):
 
     return unique_key    
 
-
 def extract_variants(vcf_input, vcf_output, min_af, max_af, dir, name):
     
     '''
@@ -171,7 +170,6 @@ def extract_variants(vcf_input, vcf_output, min_af, max_af, dir, name):
     else:
         raise ValueError("ERROR. Please provide a valid VCF file as input")
 
-
     #store the paths of the file that are going to be created to use them afterwards
     hetero_vcf_output = f"{dir}/hetero_{vcf_output}{name}.vcf"
     homo_vcf_output = f"{dir}/homo_{vcf_output}{name}.vcf"
@@ -187,27 +185,64 @@ def extract_variants(vcf_input, vcf_output, min_af, max_af, dir, name):
             if args.filter_mode: #filter-vcf is provided by the user
                  if "PASS" in record.FILTER:  # Check if FILTER annotation is "PASS"
                     af_values = record.calls[0].data.get("AF", [])  # Get AF values, obtain an empty value if its not available (debugging)
-                    if af_values and max_af > af_values[0] > min_af:  #default: max=0.70 and min=0.30                 
-                        writer_het.write_record(record)
-                        hetero_lines.append(str(record))
-                    else: #homo variants
-                        writer_homo.write_record(record)
-                        homo_lines.append(str(record))
+                    # Fix: Handle both float and list cases
+                    if af_values:
+                        if isinstance(af_values, (int, float)):
+                            af_check = af_values
+                        else:
+                            af_check = af_values[0]
+
+                        if max_af > af_check > min_af:  #default: max=0.70 and min=0.30
+                            writer_het.write_record(record)
+                            hetero_lines.append(str(record))
+                        else: #homo variants
+                            writer_homo.write_record(record)
+                            homo_lines.append(str(record))
             else:
                 # --filter-vcf option is not provided, write all variants
                 af_values = record.calls[0].data.get("AF", [])  # Get AF values, obtain an empty value if its not available (debugging)
-                if af_values and max_af > af_values[0] > min_af:  #default: max=0.70 and min=0.30                  
-                    writer_het.write_record(record)
-                    hetero_lines.append(str(record)) #count length of snps found
-                else: #homo variants
-                    writer_homo.write_record(record)
-                    homo_lines.append(str(record))
+                # Fix: Handle both float and list cases
+                if af_values:
+                    if isinstance(af_values, (int, float)):
+                        af_check = af_values
+                    else:
+                        af_check = af_values[0]
+
+                    if max_af > af_check > min_af:  #default: max=0.70 and min=0.30
+                        writer_het.write_record(record)
+                        hetero_lines.append(str(record)) #count length of snps found
+                    else: #homo variants
+                        writer_homo.write_record(record)
+                        homo_lines.append(str(record))
         else:
             continue
     
     vcf.close()
     return hetero_vcf_output, homo_vcf_output, hetero_lines, homo_lines
 
+def divide_homo_vcf(homo_vcf,args, sample):
+    vcf=vcfpy.Reader.from_path(homo_vcf, "r")
+    homo_ALT_vcf_output = f"{args.output_dir}/homo_ALT{sample}.vcf"
+    homo_REF_vcf_output =  f"{args.output_dir}/homo_REF{sample}.vcf"
+    writer_ALT=vcfpy.Writer.from_path(homo_ALT_vcf_output, vcf.header)
+    writer_REF=vcfpy.Writer.from_path(homo_REF_vcf_output, vcf.header)
+
+    for record in vcf:
+        af_values = record.calls[0].data.get("AF", [])  # Get AF values, obtain an empty value if its not available (debugging)
+        # Fix: Handle both float and list cases
+        if af_values:
+            if isinstance(af_values, (int, float)):
+                af_check = af_values
+            else:
+                af_check = af_values[0]
+
+            if af_check > args.max_af:
+                writer_ALT.write_record(record)
+            elif af_check < args.min_af:
+                writer_REF.write_record(record)
+            else:
+                continue
+    return homo_ALT_vcf_output, homo_REF_vcf_output
 
 def parse_chromosomes(ref):
 
@@ -345,12 +380,19 @@ def divide_homo_vcf(homo_vcf,args, sample):
 
     for record in vcf:
         af_values = record.calls[0].data.get("AF", [])  # Get AF values, obtain an empty value if its not available (debugging)
-        if af_values and af_values[0] >args.max_af:
-            writer_ALT.write_record(record)
-        elif af_values and af_values[0] <args.min_af:
-            writer_REF.write_record(record)
-        else:
-            continue
+        # Fix: Handle both float and list cases
+        if af_values:
+            if isinstance(af_values, (int, float)):
+                af_check = af_values
+            else:
+                af_check = af_values[0]
+
+            if af_check > args.max_af:
+                writer_ALT.write_record(record)
+            elif af_check < args.min_af:
+                writer_REF.write_record(record)
+            else:
+                continue
     return homo_ALT_vcf_output, homo_REF_vcf_output
 
 


### PR DESCRIPTION
Running with `--single-mode True` produces the same error which was resolved #15 

```console
Apptainer> jloh onco_extract --single-mode True --ref test_data/S_para.chrXII.fa --vcf test_data/out.ff.vcf --bam test_data/out.fs.bam
[Thu Oct  2 11:40:06 2025] Initiating onco_Jloh: checking conditions and organizing workspace...Done
[Thu Oct  2 11:40:06 2025] Running in --single-file mode...
[Thu Oct  2 11:40:06 2025] Extracting heterozygous and homozygous SNPs...
Traceback (most recent call last):
  File "/root/src/jloh/src/onco_extract", line 1347, in <module>
    main(args, tmp_bams, tmp_bams2)
  File "/root/src/jloh/src/onco_extract", line 1323, in main
    run_in_single_mode(args, tmp_bams, tmp_bams2)
  File "/root/src/jloh/src/onco_extract", line 1170, in run_in_single_mode
    hetero_vcf, homo_vcf, hetero_lines, homo_lines=extract_variants(args.vcf, args.sample, args.min_af, args.max_af,args.output_dir, "_tumor")
  File "/root/src/jloh/src/onco_extract", line 199, in extract_variants
    if af_values and max_af > af_values[0] > min_af:  #default: max=0.70 and min=0.30                  
TypeError: 'float' object is not subscriptable
```

Another error then appears, previously reported in #14 

```console
Apptainer> python3 src/onco_extract --single-mode True --ref test_data/S_para.chrXII.fa --vc
f test_data/out.ff.vcf --bam test_data/out.fs.bam
[Thu Oct  2 11:40:23 2025] Initiating onco_Jloh: checking conditions and organizing workspace...Done
[Thu Oct  2 11:40:23 2025] Running in --single-file mode...
[Thu Oct  2 11:40:23 2025] Extracting heterozygous and homozygous SNPs...
 -Found 12 heterozygous SNPs and 121 homozygous SNPs
[Thu Oct  2 11:40:23 2025]Calculating heterozygous and homozygous SNPs densities...Done
 -Avg. heterozygous SNPs density: 0.0117 SNPs/Kbps
 -Avg. homozygous SNPs density: 0.1183 SNPs/Kbps 

[Thu Oct  2 11:40:23 2025] Creating genome file from reference genome's chromosome lengths...Done
 -Genome file created succesfully
[Thu Oct  2 11:40:23 2025] Temporary BAMs being created...Done
[Thu Oct  2 11:40:35 2025] Clustering heterozygous and homozygous SNPs into blocks...Traceback (most recent call last):
  File "/data/rds/DGE/DUDGE/MOPOPGEN/mahmed03/genomictools/infer-heterozygosity-loss/lib/jloh/src/onco_extract", line 1389, in <module>
    main(args, tmp_bams, tmp_bams2)
  File "/data/rds/DGE/DUDGE/MOPOPGEN/mahmed03/genomictools/infer-heterozygosity-loss/lib/jloh/src/onco_extract", line 1365, in main
    run_in_single_mode(args, tmp_bams, tmp_bams2)
  File "/data/rds/DGE/DUDGE/MOPOPGEN/mahmed03/genomictools/infer-heterozygosity-loss/lib/jloh/src/onco_extract", line 1239, in run_in_single_mode
    Het_blocks, Homo_blocks_ALT, Homo_blocks_REF=snps_to_bed_blocks(args, hetero_vcf, homo_vcf_ALT,homo_vcf_REF, genome_file, "_tumor")
TypeError: snps_to_bed_blocks() takes 5 positional arguments but 6 were given
```

Correclty handling the bed blocks resolves the issue

```console
Apptainer> python3 src/onco_extract --single-mode True --ref test_data/S_para.chrXII.fa --vcf test_data/out.ff.vcf --bam test_data/out.fs.bam
[Thu Oct  2 11:41:08 2025] Initiating onco_Jloh: checking conditions and organizing workspace...Done
[Thu Oct  2 11:41:08 2025] Running in --single-file mode...
[Thu Oct  2 11:41:08 2025] Extracting heterozygous and homozygous SNPs...
 -Found 12 heterozygous SNPs and 121 homozygous SNPs
[Thu Oct  2 11:41:08 2025]Calculating heterozygous and homozygous SNPs densities...Done
 -Avg. heterozygous SNPs density: 0.0117 SNPs/Kbps
 -Avg. homozygous SNPs density: 0.1183 SNPs/Kbps 

[Thu Oct  2 11:41:08 2025] Creating genome file from reference genome's chromosome lengths...Done
 -Genome file created succesfully
[Thu Oct  2 11:41:08 2025] Temporary BAMs being created...Done
[Thu Oct  2 11:41:20 2025] Clustering heterozygous and homozygous SNPs into blocks...Done
Found:
 -1 het blocks
 -9 homo ALT blocks
 -0 homo REF blocks
[Thu Oct  2 11:41:20 2025] Adding allele type (REF/ALT) to each LOH block...Done
-10 blocks were processed
[Thu Oct  2 11:41:20 2025] Trimming overlaps of homozygous blocks with uncovered regions...Done
-12 blocks were trimmed
[Thu Oct  2 11:41:23 2025]Filtering LOH blocks with at least 100 2 bp ...Done
-9 blocks survived the filtering
[Thu Oct  2 11:41:23 2025] Computing coverage up- , in-, and downstream of any candidate block...Done
-3 blocks were processed. 
[Thu Oct  2 11:41:26 2025] Adding heterozygous and homozygous SNP counts in each block...Done
 - 3 blocks were processed
[Thu Oct  2 11:41:26 2025] Sorting LOH blocks...Done
[Thu Oct  2 11:41:26 2025] Writing to output...
[Thu Oct  2 11:41:26 2025] Done!
  - Files generated can be found on oncojloh
[Thu Oct  2 11:41:26 2025] Statistics from the run:
 - CPU time used: 13.35 seconds
 - Memory usage change: 41.57 MB
 - Elapsed time: 0 minutes
 ```