### PR TITLE
Support zipped VCF files

### DIFF
--- a/src/extract
+++ b/src/extract
@@ -211,8 +211,12 @@ def hetero_and_homo_snps(vcf):
     Last update: 04/03/2022
     """
 
-    # read SNPs
-    INPUT = open(vcf, "r")
+    # read SNPs - handle both compressed and uncompressed VCF files
+    import gzip
+    if vcf.endswith('.gz'):
+        INPUT = gzip.open(vcf, "rt")
+    else:
+        INPUT = open(vcf, "r")
     Lines = [ line for line in INPUT ]
     Header = [ line for line in Lines if line[0] == "#" ]
     Vcf_lines = [ line for line in Lines if line[0] != "#" ]
@@ -403,8 +407,18 @@ def hetero_and_homo_snp_densities(het_snps_vcf, homo_snps_vcf, ref):
     Last update: 15/03/2022
     """
 
-    Hetero_lines = [ line for line in open(het_snps_vcf, "r") if line[0] != "#" ]
-    Homo_lines = [ line for line in open(homo_snps_vcf, "r") if line[0] != "#" ]
+    # Handle both compressed and uncompressed VCF files
+    import gzip
+
+    if het_snps_vcf.endswith('.gz'):
+        Hetero_lines = [ line for line in gzip.open(het_snps_vcf, "rt") if line[0] != "#" ]
+    else:
+        Hetero_lines = [ line for line in open(het_snps_vcf, "r") if line[0] != "#" ]
+
+    if homo_snps_vcf.endswith('.gz'):
+        Homo_lines = [ line for line in gzip.open(homo_snps_vcf, "rt") if line[0] != "#" ]
+    else:
+        Homo_lines = [ line for line in open(homo_snps_vcf, "r") if line[0] != "#" ]
 
     # hetero
     Het_snp_densities = calculate_chrom_snp_densities(Hetero_lines, ref)

--- a/src/onco_extract
+++ b/src/onco_extract
@@ -374,12 +374,12 @@ def hetero_and_homo_snp_densities(ref,vcf, name):
 def divide_homo_vcf(homo_vcf,args, sample):
     vcf=vcfpy.Reader.from_path(homo_vcf, "r")
     homo_ALT_vcf_output = f"{args.output_dir}/homo_ALT{sample}.vcf"
-    homo_REF_vcf_output =  f"{args.output_dir}homo_REF{sample}.vcf"
+    homo_REF_vcf_output = f"{args.output_dir}/homo_REF{sample}.vcf"  # Added missing slash
     writer_ALT=vcfpy.Writer.from_path(homo_ALT_vcf_output, vcf.header)
     writer_REF=vcfpy.Writer.from_path(homo_REF_vcf_output, vcf.header)
 
     for record in vcf:
-        af_values = record.calls[0].data.get("AF", [])  # Get AF values, obtain an empty value if its not available (debugging)
+        af_values = record.calls[0].data.get("AF", [])
         # Fix: Handle both float and list cases
         if af_values:
             if isinstance(af_values, (int, float)):
@@ -1234,11 +1234,12 @@ def run_in_single_mode(args, tmp_bams, tmp_bams_control):
     sys.stderr.write(f"Done\n")
 
     # bed blocks
-    sys.stderr.write( f"[{at()}] Clustering heterozygous and homozygous SNPs into blocks...")
-    homo_vcf_ALT, homo_vcf_REF=divide_homo_vcf(homo_vcf, args, "_tumor")
-    Het_blocks, Homo_blocks_ALT, Homo_blocks_REF=snps_to_bed_blocks(args, hetero_vcf, homo_vcf_ALT,homo_vcf_REF, genome_file, "_tumor")
-    Het_blocks=filter_by_length(Het_blocks, args.min_length)
-    Het_blocks.saveas(f'{args.output_dir}/hetero_output_file.bed')  # Save the result to a file
+    sys.stderr.write(f"[{at()}] Clustering heterozygous and homozygous SNPs into blocks...")
+    homo_vcf_ALT, homo_vcf_REF = divide_homo_vcf(homo_vcf, args, "_tumor")
+    # FIXED: Removed extra "_tumor" parameter
+    Het_blocks, Homo_blocks_ALT, Homo_blocks_REF = snps_to_bed_blocks(args, hetero_vcf, homo_vcf_ALT, homo_vcf_REF, genome_file)
+    Het_blocks = filter_by_length(Het_blocks, args.min_length)
+    Het_blocks.saveas(f'{args.output_dir}/hetero_output_file.bed') # Save the result to a file
 
     sys.stderr.write(  "Done\n")
     sys.stderr.write(f"Found:\n -{len(Het_blocks)} het blocks\n -{len(Homo_blocks_ALT)} homo ALT blocks\n -{len(Homo_blocks_REF)} homo REF blocks\n")

--- a/src/onco_extract
+++ b/src/onco_extract
@@ -162,13 +162,11 @@ def extract_variants(vcf_input, vcf_output, min_af, max_af, dir, name):
     2. If asked, select those that have pass the filtering
     3. Divide by homo and heterozygous
     '''
-    #check vcf file extension. Only uncompressed ones are allowed at this version.
-    if vcf_input.endswith(".vcf.gz"):
-        raise ValueError("ERROR. Please unzip your VCF file to continue")
-    elif vcf_input.endswith(".vcf"):
+    #check vcf file extension. Both compressed and uncompressed VCF files are supported.
+    if vcf_input.endswith(".vcf.gz") or vcf_input.endswith(".vcf"):
         vcf=vcfpy.Reader.from_path(vcf_input, "r")
     else:
-        raise ValueError("ERROR. Please provide a valid VCF file as input")
+        raise ValueError("ERROR. Please provide a valid VCF file as input (.vcf or .vcf.gz)")
 
     #store the paths of the file that are going to be created to use them afterwards
     hetero_vcf_output = f"{dir}/hetero_{vcf_output}{name}.vcf"

--- a/src/onco_extract
+++ b/src/onco_extract
@@ -154,7 +154,6 @@ def generate_unique_key(output_dir):
 
     return unique_key    
 
-
 def extract_variants(vcf_input, vcf_output, min_af, max_af, dir, name):
     
     '''
@@ -171,7 +170,6 @@ def extract_variants(vcf_input, vcf_output, min_af, max_af, dir, name):
     else:
         raise ValueError("ERROR. Please provide a valid VCF file as input")
 
-
     #store the paths of the file that are going to be created to use them afterwards
     hetero_vcf_output = f"{dir}/hetero_{vcf_output}{name}.vcf"
     homo_vcf_output = f"{dir}/homo_{vcf_output}{name}.vcf"
@@ -187,27 +185,64 @@ def extract_variants(vcf_input, vcf_output, min_af, max_af, dir, name):
             if args.filter_mode: #filter-vcf is provided by the user
                  if "PASS" in record.FILTER:  # Check if FILTER annotation is "PASS"
                     af_values = record.calls[0].data.get("AF", [])  # Get AF values, obtain an empty value if its not available (debugging)
-                    if af_values and max_af > af_values[0] > min_af:  #default: max=0.70 and min=0.30                 
-                        writer_het.write_record(record)
-                        hetero_lines.append(str(record))
-                    else: #homo variants
-                        writer_homo.write_record(record)
-                        homo_lines.append(str(record))
+                    # Fix: Handle both float and list cases
+                    if af_values:
+                        if isinstance(af_values, (int, float)):
+                            af_check = af_values
+                        else:
+                            af_check = af_values[0]
+
+                        if max_af > af_check > min_af:  #default: max=0.70 and min=0.30
+                            writer_het.write_record(record)
+                            hetero_lines.append(str(record))
+                        else: #homo variants
+                            writer_homo.write_record(record)
+                            homo_lines.append(str(record))
             else:
                 # --filter-vcf option is not provided, write all variants
                 af_values = record.calls[0].data.get("AF", [])  # Get AF values, obtain an empty value if its not available (debugging)
-                if af_values and max_af > af_values[0] > min_af:  #default: max=0.70 and min=0.30                  
-                    writer_het.write_record(record)
-                    hetero_lines.append(str(record)) #count length of snps found
-                else: #homo variants
-                    writer_homo.write_record(record)
-                    homo_lines.append(str(record))
+                # Fix: Handle both float and list cases
+                if af_values:
+                    if isinstance(af_values, (int, float)):
+                        af_check = af_values
+                    else:
+                        af_check = af_values[0]
+
+                    if max_af > af_check > min_af:  #default: max=0.70 and min=0.30
+                        writer_het.write_record(record)
+                        hetero_lines.append(str(record)) #count length of snps found
+                    else: #homo variants
+                        writer_homo.write_record(record)
+                        homo_lines.append(str(record))
         else:
             continue
     
     vcf.close()
     return hetero_vcf_output, homo_vcf_output, hetero_lines, homo_lines
 
+def divide_homo_vcf(homo_vcf,args, sample):
+    vcf=vcfpy.Reader.from_path(homo_vcf, "r")
+    homo_ALT_vcf_output = f"{args.output_dir}/homo_ALT{sample}.vcf"
+    homo_REF_vcf_output =  f"{args.output_dir}/homo_REF{sample}.vcf"
+    writer_ALT=vcfpy.Writer.from_path(homo_ALT_vcf_output, vcf.header)
+    writer_REF=vcfpy.Writer.from_path(homo_REF_vcf_output, vcf.header)
+
+    for record in vcf:
+        af_values = record.calls[0].data.get("AF", [])  # Get AF values, obtain an empty value if its not available (debugging)
+        # Fix: Handle both float and list cases
+        if af_values:
+            if isinstance(af_values, (int, float)):
+                af_check = af_values
+            else:
+                af_check = af_values[0]
+
+            if af_check > args.max_af:
+                writer_ALT.write_record(record)
+            elif af_check < args.min_af:
+                writer_REF.write_record(record)
+            else:
+                continue
+    return homo_ALT_vcf_output, homo_REF_vcf_output
 
 def parse_chromosomes(ref):
 
@@ -345,12 +380,19 @@ def divide_homo_vcf(homo_vcf,args, sample):
 
     for record in vcf:
         af_values = record.calls[0].data.get("AF", [])  # Get AF values, obtain an empty value if its not available (debugging)
-        if af_values and af_values[0] >args.max_af:
-            writer_ALT.write_record(record)
-        elif af_values and af_values[0] <args.min_af:
-            writer_REF.write_record(record)
-        else:
-            continue
+        # Fix: Handle both float and list cases
+        if af_values:
+            if isinstance(af_values, (int, float)):
+                af_check = af_values
+            else:
+                af_check = af_values[0]
+
+            if af_check > args.max_af:
+                writer_ALT.write_record(record)
+            elif af_check < args.min_af:
+                writer_REF.write_record(record)
+            else:
+                continue
     return homo_ALT_vcf_output, homo_REF_vcf_output
 
 

--- a/src/stats
+++ b/src/stats
@@ -145,7 +145,12 @@ def get_chrom_lengths_from_vcf(vcf):
     12/08/2022
     """
 
-    IN = open(args.vcf, "r")
+    # Handle both compressed and uncompressed VCF files
+    import gzip
+    if vcf.endswith('.gz'):
+        IN = gzip.open(args.vcf, "rt")
+    else:
+        IN = open(args.vcf, "r")
     Header = [line.rstrip("\r\b\n") for line in IN if line[0] == "#"]
     IN.close()
 

--- a/src/stats
+++ b/src/stats
@@ -75,8 +75,12 @@ def hetero_and_homo_snps(vcf):
     Last update: 03/03/2022
     """
 
-    # read SNPs
-    INPUT = open(vcf, "r")
+    # read SNPs - handle both compressed and uncompressed VCF files
+    import gzip
+    if vcf.endswith('.gz'):
+        INPUT = gzip.open(vcf, "rt")
+    else:
+        INPUT = open(vcf, "r")
     Vcf_lines = [ line for line in INPUT if line[0] != "#" ]
     INPUT.close()
 


### PR DESCRIPTION
Minor changes to stop complaining about zipped vcf files, as `vcfpy` already supports it

```console
$ bcftools view test_data/out.ff.vcf -Oz -o test_data/out.ff.vcf.gz
$ tabix test_data/out.ff.vcf.gz

Apptainer> python3 src/stats --vcf test_data/out.ff.vcf.gz
[Thu Oct  2 14:31:14 2025] Reading SNPs
[Thu Oct  2 14:31:14 2025] found 19 het SNPs and 114 homo SNPs
[Thu Oct  2 14:31:14 2025] Reading chrom lengths from VCF header
[Thu Oct  2 14:31:14 2025] Read 1 chromosome names and their lengths
[Thu Oct  2 14:31:14 2025] Calculating heterozygous SNP densities
[Thu Oct  2 14:31:14 2025] Calculating homozygous SNP densities
[Thu Oct  2 14:31:15 2025] Combining to get general SNP densities


 -- SNPs/Kbp Statistics --

 S      Gen     Het     Homo
 Mean   0.19    0.15    0.4
 Max    0.48    0.2     0.88
 Min    0.08    0.08    0.04

 -- SNPs/Kbp Quantiles --

 Q      Gen     Het     Homo
 0%     0.08    0.08    0.04
 5%     0.08    0.08    0.04
 10%    0.08    0.08    0.04
 15%    0.12    0.12    0.12
 20%    0.12    0.12    0.2
 25%    0.12    0.12    0.2
 30%    0.12    0.12    0.28
 35%    0.12    0.12    0.35
 40%    0.16    0.16    0.36
 45%    0.16    0.16    0.36
 50%    0.16    0.16    0.44
 55%    0.16    0.16    0.44
 60%    0.2     0.2     0.44
 65%    0.2     0.2     0.52
 70%    0.2     0.2     0.52
 75%    0.2     0.2     0.52
 80%    0.2     0.2     0.52
 85%    0.4     0.2     0.88
 90%    0.4     0.2     0.88
 95%    0.48    0.2     0.88
```